### PR TITLE
Update switch.py

### DIFF
--- a/ns/scheduler/drr.py
+++ b/ns/scheduler/drr.py
@@ -91,6 +91,7 @@ class DRRServer:
 
         self.packets_received = 0
         self.out = None
+        self.previous = None
 
         self.upstream_updates = {}
         self.upstream_stores = {}
@@ -122,6 +123,7 @@ class DRRServer:
 
         if self.flow_classes(packet.flow_id) in self.byte_sizes:
             self.byte_sizes[self.flow_classes(packet.flow_id)] -= packet.size
+            self.previous.remove_packet(packet)
         else:
             raise ValueError(
                 "Error: the packet to be sent has never been received.")

--- a/ns/switch/switch.py
+++ b/ns/switch/switch.py
@@ -100,7 +100,7 @@ class FairPacketSwitch:
 
         for port in range(nports):
             egress_port = Port(env,
-                               rate=port_rate,
+                               rate=0,
                                qlimit=buffer_size,
                                limit_bytes=False,
                                zero_downstream_buffer=True,
@@ -142,6 +142,7 @@ class FairPacketSwitch:
                 )
 
             egress_port.out = scheduler
+            scheduler.previous = egress_port
 
             self.egress_ports.append(egress_port)
             self.ports.append(scheduler)

--- a/ns/switch/switch.py
+++ b/ns/switch/switch.py
@@ -100,7 +100,7 @@ class FairPacketSwitch:
 
         for port in range(nports):
             egress_port = Port(env,
-                               rate=0,
+                               rate=port_rate,
                                qlimit=buffer_size,
                                limit_bytes=False,
                                zero_downstream_buffer=True,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is a bug in class FairPacketSwitch: packets will never be dropped when we set queue limit based on bytes because the rate of every Port in FairPacketSwitch is always zero (line 103 in switch.py). More specifically, when we set self.rate as 0 and self.limit_bytes as true in Port, byte_count is always equal to 0 + packet.size = packet.size (line 101 in port.py), so byte_count will never >= self.qlimit, and self.packet_drop += 1 will never be used (line 112-113 in port.py). Therefore, we need to wait for the timeout correctly (line84 in port.py).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I ran a toy example with the following settings: limit_bytes as true, 2 flows in 1 port, constant arrival interval 0.5 sec, port rate 4000 bits/sec = 500 bytes/sec, buffer size 500 bytes, discipline DRR, and fixed packet length 500 bytes. In the previous ns.py, no packets will be dropped.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
