### PR TITLE
Attempts to fix TCP.

### DIFF
--- a/examples/tcp.py
+++ b/examples/tcp.py
@@ -37,7 +37,7 @@ flow = Flow(fid=0,
 
 sender = TCPPacketGenerator(env,
                             flow=flow,
-                            cc=TCPCubic(),
+                            congestion_control=TCPCubic(),
                             rtt_estimate=0.5,
                             debug=True)
 

--- a/examples/tcp.py
+++ b/examples/tcp.py
@@ -33,7 +33,8 @@ flow = Flow(fid=0,
             dst='flow 1',
             finish_time=10,
             arrival_dist=packet_arrival,
-            size_dist=packet_size)
+            size_dist=packet_size,
+            size=511)
 
 sender = TCPPacketGenerator(env,
                             flow=flow,

--- a/ns/flow/flow.py
+++ b/ns/flow/flow.py
@@ -31,6 +31,7 @@ class Flow:
     
     def init_send_buffer(self):
         if (self.typ == AppType.FILE_DOWNLD):
+            assert self.size, "Parameter size required when type is set to AppType.FILE_DOWNLD (default)."
             return self.size
         else:
             return 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

 For class `Flow`: the default `size` is `None` and the default `self.typ` is `AppType.FILE_DOWNLD`. The `init_send_buffer` method in `Flow` class may return `None` if `self.typ` is specified as `AppType.FILE_DOWNLD`. An assert statement is added to avoid this scenario. 

TCP example is currently unavailable. Call for `TCPPacketGenerator` does not match the function definition (`cc` instead of `congestion_control`). `size=511` is temporarily added to `Flow` to enable the script to execute. 

However, there are still remaining problems:

If the size is greater than 511 (i.e. larger than one TCP packet), assertion error `assert packet.delivered_time > 0` will be raised after the first TCP packet sent because `packet.delivered_time` will be zero for the second package. Suggestion: change `>` to `>=`. The issue has not been fixed to avoid further bugs.

If the above assert error is fixed by replacing `>` with `>=` and increase the size to a larger value (i.e. 20000), a `TypeError: unsupported operand type(s) for *: 'Connection' and 'float'` will be raised in `flow/cubic.py` line 73 for `target = self.origin_point + self.C * (t - self.K)**3`.

If we add `typ` argument to flow instead of `size`, i.e. `typ=None`, TCP example will continuously call `packet_arrival()` defined in `example/tcp.py`. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Current fix can only allow the TCP example to exit without any printed output. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
