### PR TITLE
Changed to let DistPacketGenerator send the first packet right after initial_delay.

### DIFF
--- a/ns/packet/dist_generator.py
+++ b/ns/packet/dist_generator.py
@@ -1,9 +1,10 @@
 """
-Implements a packet generator that simulates the sending of packets with a specified inter-
-arrival time distribution and a packet size distribution. One can set an initial delay and
-a finish time for packet generation. In addition, one can set the source id and flow ids for
-the packets generated. The DistPacketGenerator's `out` member variable is used to connect the
-generator to any network element with a `put()` member function.
+Implements a packet generator that simulates the sending of packets with a
+specified inter- arrival time distribution and a packet size distribution. One
+can set an initial delay and a finish time for packet generation. In addition,
+one can set the source id and flow ids for the packets generated. The
+DistPacketGenerator's `out` member variable is used to connect the generator to
+any network element with a `put()` member function.
 """
 
 from ns.packet.packet import Packet
@@ -75,8 +76,6 @@ class DistPacketGenerator:
                 flow_id=self.flow_id,
             )
 
-            # wait for next transmission
-            yield self.env.timeout(self.arrival_dist())
             self.out.put(packet)
 
             self.packets_sent += 1
@@ -97,3 +96,6 @@ class DistPacketGenerator:
                         self.env.now,
                     )
                 )
+
+            # waits for the next transmission
+            yield self.env.timeout(self.arrival_dist())

--- a/ns/packet/dist_generator.py
+++ b/ns/packet/dist_generator.py
@@ -20,10 +20,11 @@ class DistPacketGenerator:
     element_id: str
         the ID of this element.
     arrival_dist: function
-        A no-parameter function that returns the successive inter-arrival times of
-        the packets.
+        A no-parameter function that returns the successive inter-arrival times
+        of the packets.
     size_dist: function
-        A no-parameter function that returns the successive sizes of the packets.
+        A no-parameter function that returns the successive sizes of the
+        packets.
     initial_delay: number
         Starts generation after an initial delay. Defaults to 0.
     finish: number

--- a/ns/packet/packet.py
+++ b/ns/packet/packet.py
@@ -5,16 +5,16 @@ A very simple class that represents a packet.
 
 class Packet:
     """
-    Packets in ns.py are generally created by packet generators, and will
-    run through a queue at an output port.
+    Packets in ns.py are generally created by packet generators, and will run
+    through a queue at an output port.
 
-    Key fields include: generation time, size, flow_id, packet id, source,
-    and destination. We do not model upper layer protocols, i.e., packets
-    don't contain a payload. The size (in bytes) field is used to determine
-    its transmission time.
+    Key fields include: generation time, size, flow_id, packet id, source, and
+    destination. We do not model upper layer protocols, i.e., packets don't
+    contain a payload. The size (in bytes) field is used to determine its
+    transmission time.
 
-    We use a float to represent the size of the packet in bytes so that we
-    can compare to ideal M/M/1 queues.
+    We use a float to represent the size of the packet in bytes so that we can
+    compare to ideal M/M/1 queues.
 
     Parameters
     ----------

--- a/ns/packet/sink.py
+++ b/ns/packet/sink.py
@@ -1,10 +1,11 @@
 """
-Implements a PacketSink, designed to record both arrival times and waiting times from the incoming
-packets.
+Implements a PacketSink, designed to record both arrival times and waiting times
+from the incoming packets.
 
-By default, it records absolute arrival times, but it can also be initialized to record
-inter-arrival times.
+By default, it records absolute arrival times, but it can also be initialized to
+record inter-arrival times.
 """
+
 from collections import defaultdict as dd
 
 import simpy

--- a/ns/packet/tcp_generator.py
+++ b/ns/packet/tcp_generator.py
@@ -1,6 +1,6 @@
 """
-Implements a packet generator that simulates the TCP protocol, including support for
-various congestion control mechanisms.
+Implements a packet generator that simulates the TCP protocol, including support
+for various congestion control mechanisms.
 """
 
 import simpy

--- a/ns/packet/tcp_sink.py
+++ b/ns/packet/tcp_sink.py
@@ -1,13 +1,15 @@
 """
-Implements a TCPSink, designed to send ack packets back to the TCPPacketGenerator.
+Implements a TCPSink, designed to send ack packets back to the
+TCPPacketGenerator.
 """
+
 from ns.packet.sink import PacketSink
 from ns.packet.packet import Packet
 
 
 class TCPSink(PacketSink):
-    """A TCPSink inherits from the basic PacketSink, and sends ack packets back to the
-    TCPPacketGenerator with advertised receive window sizes.
+    """A TCPSink inherits from the basic PacketSink, and sends ack packets back to
+    the TCPPacketGenerator with advertised receive window sizes.
     """
 
     def __init__(

--- a/ns/utils/timer.py
+++ b/ns/utils/timer.py
@@ -1,6 +1,6 @@
 """
-Implements a simple timer that expires after a timeout value. When it expires, it runs
-a provided callback function.
+Implements a simple timer that expires after a timeout value. When it expires,
+it runs a provided callback function.
 """
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR changed to let DistPacketGenerator send the first packet right after initial_delay.

## Description
<!--- Describe your changes in detail -->
<!--- Describe motivation and context -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Changed to let DistPacketGenerator send the first packet right after initial_delay.
Improved some comments.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

```
python examples/basic.py
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) Fixes #
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
